### PR TITLE
Updated ReportGenerator

### DIFF
--- a/AxoCover.Dependencies/packages.config
+++ b/AxoCover.Dependencies/packages.config
@@ -6,7 +6,7 @@
   <package id="NUnit3TestAdapter.AxoCover" version="1.0.3" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="OpenCover.AxoCover" version="1.0.0" targetFramework="net45" />
-  <package id="ReportGenerator" version="2.5.6" targetFramework="net45" />
+  <package id="ReportGenerator" version="3.1.1" targetFramework="net45" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net46" />
   <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net46" />
   <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net46" />


### PR DESCRIPTION
I updated to the latest release of ReportGenerator.

The new version contains some metrics:
http://www.palmmedia.de/Blog/2017/12/6/reportgenerator-new-release-with-risk-hotspots-analysis

The metrics "NPath complexity" and "Crap Score" will not be visible. They are not in the latest OpenCover release yet.