### PR TITLE
Add 'Open coverage report' button

### DIFF
--- a/AxoCover/Models/Testing/Results/CoverageProvider.cs
+++ b/AxoCover/Models/Testing/Results/CoverageProvider.cs
@@ -40,6 +40,12 @@ namespace AxoCover.Models.Testing.Results
       _editorContext.SolutionClosing += OnSolutionClosing;
     }
 
+    public void OpenCoverageReport(string reportPath)
+    {
+      _report = GenericExtensions.ParseXml<CoverageSession>(reportPath);
+      CoverageUpdated?.Invoke(this, EventArgs.Empty);
+    }
+
     private void OnSolutionClosing(object sender, EventArgs e)
     {
       _report = null;

--- a/AxoCover/Models/Testing/Results/ICoverageProvider.cs
+++ b/AxoCover/Models/Testing/Results/ICoverageProvider.cs
@@ -8,6 +8,8 @@ namespace AxoCover.Models.Testing.Results
   {
     event EventHandler CoverageUpdated;
 
+    void OpenCoverageReport(string reportPath);
+
     Task<FileCoverage> GetFileCoverageAsync(string filePath);
 
     Task<CoverageItem> GetCoverageAsync();

--- a/AxoCover/Resources.Designer.cs
+++ b/AxoCover/Resources.Designer.cs
@@ -925,6 +925,24 @@ namespace AxoCover {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open report.
+        /// </summary>
+        public static string OpenCoverageReport {
+            get {
+                return ResourceManager.GetString("OpenCoverageReport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Coverage reports (*.xml)|*.xml|All files (*.*)|*.*.
+        /// </summary>
+        public static string OpenCoverageReportFilter {
+            get {
+                return ResourceManager.GetString("OpenCoverageReportFilter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Issue tracker.
         /// </summary>
         public static string OpenIssues {
@@ -1474,7 +1492,7 @@ namespace AxoCover {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hmm... AxoCover found no unit tests in this solution. Maybe you wanted to add a new unit test project and some tests?.
+        ///   Looks up a localized string similar to Hmm... AxoCover found no unit tests in this solution. Maybe you wanted to add a new unit test project and some tests? Or, open an existing coverage report:.
         /// </summary>
         public static string TestExplorerPlaceholder {
             get {

--- a/AxoCover/Resources.resx
+++ b/AxoCover/Resources.resx
@@ -355,7 +355,7 @@
     <value>Test execution started.</value>
   </data>
   <data name="TestExplorerPlaceholder" xml:space="preserve">
-    <value>Hmm... AxoCover found no unit tests in this solution. Maybe you wanted to add a new unit test project and some tests?</value>
+    <value>Hmm... AxoCover found no unit tests in this solution. Maybe you wanted to add a new unit test project and some tests? Or, open an existing coverage report:</value>
   </data>
   <data name="IsCoveringByTest" xml:space="preserve">
     <value>Calculate coverage of each test separately</value>
@@ -659,5 +659,11 @@
   </data>
   <data name="ShowAnchors" xml:space="preserve">
     <value>Test anchors</value>
+  </data>
+  <data name="OpenCoverageReport" xml:space="preserve">
+    <value>Open report</value>
+  </data>
+  <data name="OpenCoverageReportFilter" xml:space="preserve">
+    <value>Coverage reports (*.xml)|*.xml|All files (*.*)|*.*</value>
   </data>
 </root>

--- a/AxoCover/ViewModels/TestExplorerViewModel.cs
+++ b/AxoCover/ViewModels/TestExplorerViewModel.cs
@@ -19,6 +19,7 @@ namespace AxoCover.ViewModels
 {
   public class TestExplorerViewModel : ViewModel
   {
+    private readonly ICoverageProvider _coverageProvider;
     private readonly IEditorContext _editorContext;
     private readonly ITestProvider _testProvider;
     private readonly ITestRunner _testRunner;
@@ -292,6 +293,14 @@ namespace AxoCover.ViewModels
       }
     }
 
+    public ICommand OpenCoverageReportCommand
+    {
+      get
+      {
+        return new DelegateCommand(OpenCoverageReport);
+      }
+    }
+
     public ICommand RunTestsCommand
     {
       get
@@ -371,6 +380,7 @@ namespace AxoCover.ViewModels
       };
       SearchViewModel = new CodeItemSearchViewModel<TestItemViewModel, TestItem>();
 
+      _coverageProvider = coverageProvider;
       _editorContext = editorContext;
       _testProvider = testProvider;
       _testRunner = testRunner;
@@ -419,6 +429,16 @@ namespace AxoCover.ViewModels
     }
 
     bool _suppressAutoLoadAndRun = false;
+
+    private async void OpenCoverageReport(object parameter)
+    {
+      if (parameter == null) return ;
+
+      _coverageProvider.OpenCoverageReport((string)parameter);
+      IsReportAvailable = true;
+      SetStateToReady();
+      IsReportTabSelected = true;
+    }
 
     private async void RunTestItem(TestItemViewModel target, bool isCovering, bool isDebugging, bool isCoverAfterBuild = false)
     {

--- a/AxoCover/Views/TestExplorerView.xaml
+++ b/AxoCover/Views/TestExplorerView.xaml
@@ -229,6 +229,11 @@
                                              Icon="/AxoCover;component/Resources/collapse.png"
                                              Command="{Binding CollapseAllCommand}"
                                              Visibility="{Binding IsFiltering, Source={x:Reference _searchBox}, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"/>
+                      <controls:ActionButton Text="{x:Static res:Resources.OpenCoverageReport}"
+                                             Icon="/AxoCover;component/Resources/open.png"
+                                             Command="{Binding OpenCoverageReportCommand}"
+                                             CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"
+                                             Click="OnOpenCoverageReportClick"/>
                     </UniformGrid>
 
                     <controls:SearchBox DockPanel.Dock="Top" x:Name="_searchBox"
@@ -275,6 +280,13 @@
                               Visibility="{Binding TestSolution.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <TextBlock Text="{x:Static res:Resources.TestExplorerPlaceholder}"
                                TextWrapping="Wrap" Margin="12" HorizontalAlignment="Center" TextAlignment="Center"/>
+                    <StackPanel Margin="12">
+                      <controls:ActionButton Text="{x:Static res:Resources.OpenCoverageReport}"
+                                             Icon="/AxoCover;component/Resources/open.png"
+                                             Command="{Binding OpenCoverageReportCommand}"
+                                             CommandParameter="{Binding Tag, RelativeSource={RelativeSource Self}}"
+                                             Click="OnOpenCoverageReportClick"/>
+                    </StackPanel>
                     <StackPanel Margin="12">
                       <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" Text="{x:Static res:Resources.SupportedTestFrameworks}" Margin="3"/>
                       <WrapPanel HorizontalAlignment="Center">

--- a/AxoCover/Views/TestExplorerView.xaml.cs
+++ b/AxoCover/Views/TestExplorerView.xaml.cs
@@ -61,5 +61,14 @@ namespace AxoCover.Views
         e.Handled = true;
       }
     }
+
+    private void OnOpenCoverageReportClick(object sender, RoutedEventArgs e)
+    {
+      var ofd = new Microsoft.Win32.OpenFileDialog();
+      ofd.Filter = AxoCover.Resources.OpenCoverageReportFilter;
+      ofd.CheckFileExists = true;
+
+      ((FrameworkElement)sender).Tag = ofd.ShowDialog() == true ? ofd.FileName : null;
+    }
   }
 }


### PR DESCRIPTION
This PR adds an "Open coverage report" button to the Test tab. It is useful to view coverage reports generated offline, e.g. on build servers by CI infrastructure, and is also a stop-gap solution to work around platform or test framework support issues.